### PR TITLE
Update dependencies to released versions and improve README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,6 @@ on:
     branches:
       - main
 
-env:
-  # Need to set this to avoid pipenv syncing an entire LFS repo and failing with bandwidth quota (see
-  # https://github.com/the-grey-group/datalab/issues/603)
-  GIT_LFS_SKIP_SMUDGE: 1
-
 jobs:
 
   pytest:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Ben Smith
+Copyright (c) 2021-2024 Ben Smith
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ requests = "*"
 numpy = "*"
 pandas = "*"
 openpyxl = "*"
-galvani = { git = "git+https://github.com/echemdata/galvani@ml-evs/analog-in-fix" }
+galvani = ">= 0.4.1"
 NewareNDA = "*"
 scipy = "*"
 matplotlib = "*"

--- a/README.md
+++ b/README.md
@@ -1,27 +1,57 @@
 # navani
-Module for processing and plotting electrochemical data from battery cyclers. Conatins functions to extract dQ/dV.
 
-The main dependencies are galvani and mdbtools.
+Module for processing and plotting electrochemical data from battery cyclers, combining other open source libraries to create pandas dataframes with a normalized schema across multiple cycler brands.
+Contains functions to compute dQ/dV and dV/dQ.
 
-galvani : https://github.com/echemdata/galvani
-This can be installed using pip:
-`pip install galvani`
+Currently supports:
 
-mdbtools
-This can be installed on linux and mac using:
-`sudo apt install mdbtools`
+- BioLogic MPR (`.mpr`)
+- Arbin res files (`.res`)
+- Simple `.txt` and Excel `.xls`/`.xlsx` formats produced by e.g., Arbin, Ivium and Lanhe/Lande
+- Neware NDA and NDAX (`.nda`, `.ndax`)
 
+The main dependencies are :
 
+- pandas
+- [galvani](https://github.com/echemdata/galvani) (BioLogic MPR) 
+- [mdbtools](https://github.com/mdbtools/mdbtools) (for reading Arbin's .res files with galvani).
+- [NewareNDA](https://github.com/Solid-Energy-Systems/NewareNDA) (for reading Neware's NDA and NDAx formats).
+
+## Installation
+
+It is stronly recommended to use a fresh Python environment to install navani, using e.g., `conda create` or `python -m venv <chosen directory`.
+To install navani, either clone this repository and install from your local copy:
+
+```shell
+git clone git@github.com/BenSmithGreyGroup/navani
+cd navani
+pip install .
 ```
+
+or install directly from GitHub with `pip`:
+
+```shell
+pip install git+https://github.com/BenSmithGreyGroup/navani
+```
+
+The additional non-Python mdbtools dependency to `galvani` that is required to read Arbin's `.res` format can be installed on Ubuntu via `sudo apt install mdbtools`, with similar instructions available for other Linux distributions.
+
+## Usage
+
+The main entry point to navani is the `navani.echem.echem_file_loader` function, which will do file type detection and return a pandas dataframe.
+Many different plot types are then available, as shown below:
+
+```python
 import pandas as pd
 import navani.echem as ec
 
 df = ec.echem_file_loader(filepath)
 fig, ax = ec.charge_discharge_plot(df, 1)
 ```
+
 <img src="Example_figures/Graphite_charge_discharge_plot.png" width="50%" height="50%">
 
-```
+```python
 for cycle in [1, 2]:
     mask = df['half cycle'] == cycle
     voltage, dqdv, capacity = ec.dqdv_single_cycle(df['Capacity'][mask], df['Voltage'][mask],
@@ -37,9 +67,10 @@ plt.xlim(0, 0.5)
 plt.xlabel('Voltage / V')
 plt.ylabel('dQ/dV / mAhV$^{-1}$')
 ```
+
 <img src="Example_figures/Graphite_dqdv.png" width="50%" height="50%">
 
-```
+```python
 fig, ax = ec.multi_dqdv_plot(df, cycles=cycles,
                     colormap='plasma',
                     window_size_1=51,

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     install_requires=['numpy', 'pandas', 'scipy', 'galvani >= 0.4.1', 'matplotlib', 'openpyxl', 'NewareNDA'],
     tests_require=['pytest'],
     # *strongly* suggested for sharing
-    version='0.1.3',
+    version='0.1.5',
     # The license can be anything you like
     license='MIT',
     description='Package for processing and plotting echem data from cyclers',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     # Needed to actually package something
     packages=['navani'],
     # Needed for dependencies
-    install_requires=['numpy', 'pandas', 'scipy', 'galvani @ git+https://github.com/echemdata/galvani@master#egg=galvani', 'matplotlib', 'openpyxl', 'NewareNDA'],
+    install_requires=['numpy', 'pandas', 'scipy', 'galvani >= 0.4.1', 'matplotlib', 'openpyxl', 'NewareNDA'],
     tests_require=['pytest'],
     # *strongly* suggested for sharing
     version='0.1.3',


### PR DESCRIPTION
As above -- this PR sets galvani to the now-released 0.4.1, with support for ECLab >= 11.50. It also updates the README with better instructions and more detail, and bumps the version number to v0.1.5.