### PR TITLE
Attempt to make current units consistent across neware/BDF

### DIFF
--- a/src/navani/bdf.py
+++ b/src/navani/bdf.py
@@ -94,7 +94,7 @@ def bdf_processing(df: pd.DataFrame) -> pd.DataFrame:
     # Create navani columns from BDF columns
     df['Time'] = df['Test Time / s']
     df['Voltage'] = df['Voltage / V']
-    df['Current'] = df['Current / A'] * 1000  # A -> mA
+    df['Current'] = df['Current / A'] / 1000  # A -> mA
 
     # Determine state from current direction
     def bdf_state(x: float):
@@ -159,7 +159,7 @@ def export_to_bdf(df: pd.DataFrame, save: bool = False, filepath: Optional[Union
     # Required: Test Time / s, Voltage / V, Current / A - note Current is converted from mA to A
     bdf_df['Test Time / s'] = bdf_df['Time']
     bdf_df['Voltage / V'] = bdf_df['Voltage']
-    bdf_df['Current / A'] = bdf_df['Current'] / 1000
+    bdf_df['Current / A'] = bdf_df['Current'] * 1000
 
     # Recommended: Cycle Count / 1
     if 'full cycle' in bdf_df.columns:

--- a/src/navani/bdf.py
+++ b/src/navani/bdf.py
@@ -94,7 +94,7 @@ def bdf_processing(df: pd.DataFrame) -> pd.DataFrame:
     # Create navani columns from BDF columns
     df['Time'] = df['Test Time / s']
     df['Voltage'] = df['Voltage / V']
-    df['Current'] = df['Current / A'] / 1000  # A -> mA
+    df['Current'] = df['Current / A'] * 1000  # A -> mA
 
     # Determine state from current direction
     def bdf_state(x: float):
@@ -159,7 +159,7 @@ def export_to_bdf(df: pd.DataFrame, save: bool = False, filepath: Optional[Union
     # Required: Test Time / s, Voltage / V, Current / A - note Current is converted from mA to A
     bdf_df['Test Time / s'] = bdf_df['Time']
     bdf_df['Voltage / V'] = bdf_df['Voltage']
-    bdf_df['Current / A'] = bdf_df['Current'] * 1000
+    bdf_df['Current / A'] = bdf_df['Current'] / 1000
 
     # Recommended: Cycle Count / 1
     if 'full cycle' in bdf_df.columns:

--- a/src/navani/neware.py
+++ b/src/navani/neware.py
@@ -36,7 +36,7 @@ def neware_reader_nda(filename: Union[str, Path], expected_capacity_unit: str = 
     else:
         raise RuntimeError(f"Unexpected capacity unit: {expected_capacity_unit=}, should be one of 'mAh', 'Ah'.")
 
-    df["Current"] = 1000 * df["Current(mA)"]
+    df["Current"] = df["Current(mA)"]
     df["state"] = pd.Categorical(values=["unknown"] * len(df["Status"]), categories=["R", 1, 0, "unknown"])
     df.loc[df["Status"] == "Rest", "state"] = "R"
     df.loc[df["Status"] == "CC_Chg", "state"] = 0

--- a/tests/test_echem.py
+++ b/tests/test_echem.py
@@ -221,9 +221,9 @@ def test_ndax():
 
     assert all(c in df for c in cols), f"Some columns from {cols} were missing in {df.columns}"
 
-    assert np.testing.assert_almost_equal(df["Current"].max(), 0.12)
-    assert np.testing.assert_almost_equal(df["Current"].mean(), -0.00276)
-    assert np.testing.assert_almost_equal(df["Voltage"].max(), 4.3998)
+    np.testing.assert_almost_equal(df["Current"].max(), 0.12)
+    np.testing.assert_almost_equal(df["Current"].mean(), -0.00276)
+    np.testing.assert_almost_equal(df["Voltage"].max(), 4.3998)
     assert df.shape[0] == 1464
 
 @pytest.mark.parametrize("test_path", [

--- a/tests/test_echem.py
+++ b/tests/test_echem.py
@@ -221,9 +221,9 @@ def test_ndax():
 
     assert all(c in df for c in cols), f"Some columns from {cols} were missing in {df.columns}"
 
-    np.testing.assert_almost_equal(df["Current"].max(), 0.12)
-    np.testing.assert_almost_equal(df["Current"].mean(), -0.00276)
-    np.testing.assert_almost_equal(df["Voltage"].max(), 4.3998)
+    np.testing.assert_almost_equal(df["Current"].max(), 0.12, decimal=2)
+    np.testing.assert_almost_equal(df["Current"].mean(), -0.00276, decimal=5)
+    np.testing.assert_almost_equal(df["Voltage"].max(), 4.3998, decimal=4)
     assert df.shape[0] == 1464
 
 @pytest.mark.parametrize("test_path", [

--- a/tests/test_echem.py
+++ b/tests/test_echem.py
@@ -204,6 +204,7 @@ def test_nda():
 
 def test_ndax():
     import navani.echem as ec 
+    import numpy as np
 
     test_path = pathlib.Path(__file__).parent.parent / "Example_data" / "test.ndax"
 
@@ -219,6 +220,11 @@ def test_ndax():
     )
 
     assert all(c in df for c in cols), f"Some columns from {cols} were missing in {df.columns}"
+
+    assert np.testing.assert_almost_equal(df["Current"].max(), 0.12)
+    assert np.testing.assert_almost_equal(df["Current"].mean(), -0.00276)
+    assert np.testing.assert_almost_equal(df["Voltage"].max(), 4.3998)
+    assert df.shape[0] == 1464
 
 @pytest.mark.parametrize("test_path", [
     "00_test_01_OCV_C01.mpr",


### PR DESCRIPTION
Fixes root cause of https://github.com/datalab-org/datalab/pull/1723, where we were assuming that the navani column `Current` is always in mA.

I think the following was happening:

NewareNDA returns a `current(mA)` column definitely in mA; we were inflating that to A when creating the navani column, even though the `Current` in the docs says its "usually" in mA.

~This was already being corrected for when doing BDF exports, though more by luck than judgement.~
Not sure of this anymore...

Likely we should add some more tests of parsed values to the resulting files, and better document what units these dataframes are expected to have (and where the edge cases are). 

~I think the test failures are wrong, i.e., the values are now correct, but this should be carefully reviewed (I won't update them myself)~ Even my own attempt to change this shows a lack of caffeine...