### PR TITLE
Bdf saving restructure

### DIFF
--- a/src/navani/bdf.py
+++ b/src/navani/bdf.py
@@ -183,6 +183,103 @@ def _downcast_bdf_columns(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
+def build_bdf_df(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Build a BDF-standard DataFrame from a navani-processed DataFrame.
+
+    BDF-standard columns are added with appropriate unit conversions (mA -> A, mAh -> Ah),
+    navani-only duplicate columns are dropped, and numeric columns are downcast to
+    float32/int32 to reduce file size.
+
+    Args:
+        df (pandas.DataFrame): A navani-processed DataFrame (from echem_file_loader).
+
+    Returns:
+        pd.DataFrame: A new DataFrame containing only BDF-standard columns.
+
+    Raises:
+        ValueError: If required navani columns (Time, Voltage, Current) are missing.
+    """
+    required_columns = {'Time', 'Voltage', 'Current'}
+    missing = required_columns - set(df.columns)
+    if missing:
+        raise ValueError(f'Input DataFrame missing required columns for BDF export: {missing}')
+
+    bdf_df = df.copy()
+
+    # Required: Test Time / s, Voltage / V, Current / A - note Current is converted from mA to A
+    bdf_df['Test Time / s'] = bdf_df['Time']
+    bdf_df['Voltage / V'] = bdf_df['Voltage']
+    bdf_df['Current / A'] = bdf_df['Current'] / 1000
+
+    # Recommended: Cycle Count / 1
+    if 'full cycle' in bdf_df.columns:
+        bdf_df['Cycle Count / 1'] = bdf_df['full cycle']
+
+    # Optional: Step Index / 1 - prioritise existing step index columns, then landdt state, then state
+    step_col = None
+    for col_name in step_index_columns:
+        if col_name in bdf_df.columns:
+            step_col = col_name
+            break
+    if step_col is not None:
+        bdf_df['Step Index / 1'] = bdf_df[step_col]
+    elif landdt_step_column in bdf_df.columns and bdf_df[landdt_step_column].dtype == object:
+        bdf_df['Step Index / 1'] = bdf_df[landdt_step_column].astype('category').cat.codes
+    elif 'state' in bdf_df.columns:
+        bdf_df['Step Index / 1'] = bdf_df['state'].astype('category').cat.codes
+
+    # Recommended: Step Count / 1 - increases each time Step Index / 1 changes
+    if 'Step Index / 1' in bdf_df.columns:
+        bdf_df['Step Count / 1'] = (bdf_df['Step Index / 1'] != bdf_df['Step Index / 1'].shift()).cumsum()
+
+    # Optional: Charging and Discharging Capacity / Ah (mAh -> Ah)
+    if 'Capacity' in bdf_df.columns and 'state' in bdf_df.columns:
+        bdf_df['Charging Capacity / Ah'] = 0.0
+        bdf_df['Discharging Capacity / Ah'] = 0.0
+        charge_mask = bdf_df['state'] == 0
+        discharge_mask = bdf_df['state'] == 1
+        bdf_df.loc[charge_mask, 'Charging Capacity / Ah'] = bdf_df.loc[charge_mask, 'Capacity'] / 1000
+        bdf_df.loc[discharge_mask, 'Discharging Capacity / Ah'] = bdf_df.loc[discharge_mask, 'Capacity'] / 1000
+
+    bdf_cols = [c for c in bdf_df.columns if c in _BDF_CANONICAL_COLUMNS]
+    bdf_df = bdf_df[bdf_cols]
+    _downcast_bdf_columns(bdf_df)
+    return bdf_df
+
+
+def save_bdf(
+    bdf_df: pd.DataFrame,
+    parquet_path: Optional[Union[str, Path]] = None,
+    csv_path: Optional[Union[str, Path]] = None,
+    parquet_compression: str = 'zstd',
+) -> None:
+    """
+    Save a BDF DataFrame (from build_bdf_df) to parquet and/or CSV.
+
+    Args:
+        bdf_df (pd.DataFrame): A BDF-standard DataFrame as returned by build_bdf_df.
+        parquet_path (str or Path): Full output path for the .bdf.parquet file, or None to skip.
+        csv_path (str or Path): Full output path for the .bdf.csv file, or None to skip.
+        parquet_compression (str): Parquet compression codec. Defaults to 'zstd'.
+
+    Raises:
+        ImportError: If pyarrow is not installed and parquet_path is provided.
+    """
+    if parquet_path is not None:
+        try:
+            import pyarrow  # noqa: F401
+        except ImportError:
+            raise ImportError(
+                'Writing .bdf.parquet files requires pyarrow. '
+                'Install it with: pip install navani[parquet]'
+            )
+        bdf_df.to_parquet(parquet_path, index=False, compression=parquet_compression)
+
+    if csv_path is not None:
+        bdf_df.to_csv(csv_path, index=False)
+
+
 def export_to_bdf(
     df: pd.DataFrame,
     bdf_only: bool = False,
@@ -195,6 +292,8 @@ def export_to_bdf(
 ) -> pd.DataFrame:
     """
     Export a navani DataFrame to Battery Data Format (BDF).
+
+    Deprecated: use build_bdf_df() and save_bdf() instead.
 
     BDF-standard columns are added with appropriate unit conversions (mA -> A, mAh -> Ah).
     Numeric columns are downcast to float32/int32 to reduce file size.
@@ -224,76 +323,30 @@ def export_to_bdf(
     """
     if (save_csv or save_parquet) and filepath is None:
         raise ValueError('filepath must be provided when save_csv or save_parquet is True.')
-    bdf_df = df.copy()
 
-    required_columns = {'Time', 'Voltage', 'Current'}
-    missing = required_columns - set(bdf_df.columns)
-    if missing:
-        raise ValueError(f'Input DataFrame missing required columns for BDF export: {missing}')
-
-    # Required: Test Time / s, Voltage / V, Current / A - note Current is converted from mA to A
-    bdf_df['Test Time / s'] = bdf_df['Time']
-    bdf_df['Voltage / V'] = bdf_df['Voltage']
-    bdf_df['Current / A'] = bdf_df['Current'] / 1000
-
-    # Recommended: Cycle Count / 1
-    if 'full cycle' in bdf_df.columns:
-        bdf_df['Cycle Count / 1'] = bdf_df['full cycle']
-
-    # Optional: Step Index / 1 - try to find a suitable column for this, prioritising existing step index columns, then landdt state column, then state column
-    step_col = None
-    for col_name in step_index_columns:
-        if col_name in bdf_df.columns:
-            step_col = col_name
-            break
-    if step_col is not None:
-        bdf_df['Step Index / 1'] = bdf_df[step_col]
-    # Landdt uses a string "State" column - encode unique strings as integers
-    elif landdt_step_column in bdf_df.columns and bdf_df[landdt_step_column].dtype == object:
-        bdf_df['Step Index / 1'] = bdf_df[landdt_step_column].astype('category').cat.codes
-    elif 'state' in bdf_df.columns:
-        bdf_df['Step Index / 1'] = bdf_df['state'].astype('category').cat.codes
-
-    # Recommended: Step Count / 1 - increases each time Step Index / 1 changes
-    if 'Step Index / 1' in bdf_df.columns:
-        bdf_df['Step Count / 1'] = (bdf_df['Step Index / 1'] != bdf_df['Step Index / 1'].shift()).cumsum()
-
-    # Optional: Charging and Discharging Capacity / Ah (mAh -> Ah)
-    if 'Capacity' in bdf_df.columns and 'state' in bdf_df.columns:
-        bdf_df['Charging Capacity / Ah'] = 0.0
-        bdf_df['Discharging Capacity / Ah'] = 0.0
-        charge_mask = bdf_df['state'] == 0
-        discharge_mask = bdf_df['state'] == 1
-        bdf_df.loc[charge_mask, 'Charging Capacity / Ah'] = bdf_df.loc[charge_mask, 'Capacity'] / 1000
-        bdf_df.loc[discharge_mask, 'Discharging Capacity / Ah'] = bdf_df.loc[discharge_mask, 'Capacity'] / 1000
-
-    if bdf_only or save_csv or save_parquet:
-        bdf_cols = [c for c in bdf_df.columns if c in _BDF_CANONICAL_COLUMNS]
-        bdf_df = bdf_df[bdf_cols]
-
-    _downcast_bdf_columns(bdf_df)
+    bdf_df = build_bdf_df(df)
 
     if save_csv or save_parquet:
         stem = Path(filepath)
-        # Strip any existing .bdf.* extension so callers can pass either a bare stem or a full path
         while stem.suffix in ('.csv', '.parquet', '.gz', '.bdf'):
             stem = stem.with_suffix('')
-
-    if save_csv:
-        bdf_df.to_csv(stem.parent / (stem.name + '.bdf.csv'), index=False)
-
-    if save_parquet:
-        try:
-            import pyarrow  # noqa: F401
-        except ImportError:
-            raise ImportError(
-                'Writing .bdf.parquet files requires pyarrow. '
-                'Install it with: pip install navani[parquet]'
-            )
-        bdf_df.to_parquet(stem.parent / (stem.name + '.bdf.parquet'), index=False, compression=parquet_compression)
+        save_bdf(
+            bdf_df,
+            parquet_path=stem.parent / (stem.name + '.bdf.parquet') if save_parquet else None,
+            csv_path=stem.parent / (stem.name + '.bdf.csv') if save_csv else None,
+            parquet_compression=parquet_compression,
+        )
 
     # Legacy save=True/filepath support
     if save and filepath is not None:
         bdf_df.to_csv(filepath, index=False)
+
+    if not bdf_only and not save_csv and not save_parquet:
+        # Caller wants BDF columns added but navani columns preserved — merge back
+        result = df.copy()
+        for col in bdf_df.columns:
+            result[col] = bdf_df[col].values
+        _downcast_bdf_columns(result)
+        return result
 
     return bdf_df

--- a/tests/test_echem.py
+++ b/tests/test_echem.py
@@ -1,7 +1,7 @@
 import pathlib
 
 import pytest
-from navani.bdf import export_to_bdf, _BDF_CANONICAL_COLUMNS
+from navani.bdf import build_bdf_df, export_to_bdf, save_bdf, _BDF_CANONICAL_COLUMNS
 
 EXAMPLE_DATA = pathlib.Path(__file__).parent.parent / "Example_data"
 
@@ -312,97 +312,57 @@ ALL_EXAMPLE_FILES = [
 ]
 
 
-@pytest.mark.parametrize("filename", ALL_EXAMPLE_FILES)
-def test_bdf_export_round_trip(filename, tmp_path):
-    """Test exporting each format to BDF and re-importing gives consistent data."""
-    import navani.echem as ec
-    import numpy as np
-
-    df_original = ec.echem_file_loader(EXAMPLE_DATA / filename)
-
-    export_to_bdf(df_original, filepath=tmp_path / "export", save_csv=True)
-    bdf_path = tmp_path / "export.bdf.csv"
-
-    df_reimported = ec.echem_file_loader(bdf_path)
-
-    expected_cols = ("state", "cycle change", "half cycle", "Capacity", "Voltage", "Current", "full cycle")
-    assert all(c in df_reimported for c in expected_cols)
-
-    # Voltage should survive unchanged
-    np.testing.assert_array_almost_equal(
-        df_original['Voltage'].values,
-        df_reimported['Voltage'].values,
-        decimal=5,
-    )
-
-    # Current should survive the round trip (mA -> A -> mA)
-    np.testing.assert_array_almost_equal(
-        df_original['Current'].values,
-        df_reimported['Current'].values,
-        decimal=3,
-    )
+_NAVANI_COLS = {'Time', 'Voltage', 'Current', 'Capacity', 'state', 'half cycle', 'full cycle', 'cycle change'}
+_BDF_REQUIRED = {'Test Time / s', 'Voltage / V', 'Current / A'}
 
 
 @pytest.mark.parametrize("filename", ALL_EXAMPLE_FILES)
-def test_bdf_export_has_required_columns(filename, tmp_path):
-    """Test that BDF export contains all required and recommended BDF columns."""
+def test_build_bdf_df_has_required_columns(filename):
+    """Test that build_bdf_df returns all required and recommended BDF columns."""
     import navani.echem as ec
-    import pandas as pd
 
     df = ec.echem_file_loader(EXAMPLE_DATA / filename)
+    bdf_df = build_bdf_df(df)
 
-    export_to_bdf(df, filepath=tmp_path / "export", save_csv=True)
-    bdf_df = pd.read_csv(tmp_path / "export.bdf.csv")
-    # BDF required
-    assert 'Test Time / s' in bdf_df.columns
-    assert 'Voltage / V' in bdf_df.columns
-    assert 'Current / A' in bdf_df.columns
-    # BDF recommended
+    assert _BDF_REQUIRED.issubset(bdf_df.columns)
     assert 'Cycle Count / 1' in bdf_df.columns
     assert 'Step Count / 1' in bdf_df.columns
 
 
 @pytest.mark.parametrize("filename", ALL_EXAMPLE_FILES)
-def test_bdf_export_step_count_is_numeric(filename, tmp_path):
-    """Test that Step Count / 1 is always numeric in the exported BDF."""
+def test_build_bdf_df_drops_navani_columns(filename):
+    """Test that build_bdf_df returns only BDF-standard columns."""
     import navani.echem as ec
-    import pandas as pd
+
+    df = ec.echem_file_loader(EXAMPLE_DATA / filename)
+    bdf_df = build_bdf_df(df)
+
+    assert not _NAVANI_COLS.intersection(bdf_df.columns), (
+        f"navani columns found in build_bdf_df output: {_NAVANI_COLS.intersection(bdf_df.columns)}"
+    )
+    assert set(bdf_df.columns).issubset(_BDF_CANONICAL_COLUMNS)
+
+
+@pytest.mark.parametrize("filename", ALL_EXAMPLE_FILES)
+def test_build_bdf_df_step_count_is_numeric(filename):
+    """Test that Step Count / 1 is always numeric in the BDF DataFrame."""
+    import navani.echem as ec
     import numpy as np
 
     df = ec.echem_file_loader(EXAMPLE_DATA / filename)
-
-    export_to_bdf(df, filepath=tmp_path / "export", save_csv=True)
-    bdf_df = pd.read_csv(tmp_path / "export.bdf.csv")
+    bdf_df = build_bdf_df(df)
     assert np.issubdtype(bdf_df['Step Count / 1'].dtype, np.number)
 
 
 @pytest.mark.parametrize("filename", ALL_EXAMPLE_FILES)
-def test_bdf_export_bdf_only_drops_navani_columns(filename):
-    """Test that bdf_only=True returns only BDF-standard columns."""
-    import navani.echem as ec
-
-    df = ec.echem_file_loader(EXAMPLE_DATA / filename)
-    bdf_df = export_to_bdf(df, bdf_only=True)
-
-    navani_cols = {'Time', 'Voltage', 'Current', 'Capacity', 'state', 'half cycle', 'full cycle', 'cycle change'}
-    assert not navani_cols.intersection(bdf_df.columns), (
-        f"navani columns found in bdf_only output: {navani_cols.intersection(bdf_df.columns)}"
-    )
-    assert set(bdf_df.columns).issubset(_BDF_CANONICAL_COLUMNS)
-    assert {'Test Time / s', 'Voltage / V', 'Current / A'}.issubset(bdf_df.columns)
-
-
-@pytest.mark.parametrize("filename", ALL_EXAMPLE_FILES)
-def test_bdf_export_bdf_only_round_trip(filename):
-    """Test that a bdf_only export round-trips correctly through bdf_processing."""
+def test_build_bdf_df_round_trip(filename):
+    """Test that build_bdf_df output round-trips correctly through bdf_processing."""
     import navani.echem as ec
     import numpy as np
+    from navani.bdf import bdf_processing
 
     df_original = ec.echem_file_loader(EXAMPLE_DATA / filename)
-    bdf_df = export_to_bdf(df_original, bdf_only=True)
-
-    # bdf_processing reconstructs navani columns from BDF columns
-    from navani.bdf import bdf_processing
+    bdf_df = build_bdf_df(df_original)
     df_reconstructed = bdf_processing(bdf_df.copy())
 
     np.testing.assert_array_almost_equal(
@@ -415,37 +375,96 @@ def test_bdf_export_bdf_only_round_trip(filename):
 
 
 @pytest.mark.parametrize("filename", ALL_EXAMPLE_FILES)
-def test_export_to_bdf_parquet(filename, tmp_path):
-    """Test that export_to_bdf_parquet writes a readable parquet with BDF-only columns and reduced dtypes."""
+def test_save_bdf_csv_round_trip(filename, tmp_path):
+    """Test saving to CSV and re-importing gives consistent data."""
+    import navani.echem as ec
+    import numpy as np
+
+    df_original = ec.echem_file_loader(EXAMPLE_DATA / filename)
+    bdf_df = build_bdf_df(df_original)
+    csv_path = tmp_path / "export.bdf.csv"
+    save_bdf(bdf_df, csv_path=csv_path)
+
+    assert csv_path.exists()
+    df_reimported = ec.echem_file_loader(csv_path)
+
+    expected_cols = ("state", "cycle change", "half cycle", "Capacity", "Voltage", "Current", "full cycle")
+    assert all(c in df_reimported for c in expected_cols)
+    np.testing.assert_array_almost_equal(
+        df_original['Voltage'].values, df_reimported['Voltage'].values, decimal=5,
+    )
+    np.testing.assert_array_almost_equal(
+        df_original['Current'].values, df_reimported['Current'].values, decimal=3,
+    )
+
+
+@pytest.mark.parametrize("filename", ALL_EXAMPLE_FILES)
+def test_save_bdf_parquet(filename, tmp_path):
+    """Test that save_bdf writes a readable parquet with BDF-only columns and reduced dtypes."""
     import navani.echem as ec
     import pandas as pd
     import numpy as np
 
     pytest.importorskip("pyarrow")
     df = ec.echem_file_loader(EXAMPLE_DATA / filename)
-    parquet_path = tmp_path / "test"
-    export_to_bdf(df, filepath=parquet_path, save_parquet=True)
+    bdf_df = build_bdf_df(df)
     parquet_path = tmp_path / "test.bdf.parquet"
+    save_bdf(bdf_df, parquet_path=parquet_path)
 
     assert parquet_path.exists()
     cached = pd.read_parquet(parquet_path)
 
-    # Only BDF columns
     assert set(cached.columns).issubset(_BDF_CANONICAL_COLUMNS)
-    assert {'Test Time / s', 'Voltage / V', 'Current / A'}.issubset(cached.columns)
-    navani_cols = {'Time', 'Voltage', 'Current', 'Capacity', 'state'}
-    assert not navani_cols.intersection(cached.columns)
-
-    # Dtype downcasting applied
+    assert _BDF_REQUIRED.issubset(cached.columns)
+    assert not {'Time', 'Voltage', 'Current', 'Capacity', 'state'}.intersection(cached.columns)
     assert cached['Voltage / V'].dtype == np.float32
     assert cached['Current / A'].dtype == np.float32
 
-    # Round-trips correctly via echem_file_loader
     df_loaded = ec.echem_file_loader(parquet_path)
     np.testing.assert_array_almost_equal(
         df['Voltage'].values, df_loaded['Voltage'].values, decimal=4
     )
     assert len(df_loaded) == len(df)
+
+
+@pytest.mark.parametrize("filename", ALL_EXAMPLE_FILES)
+def test_save_bdf_csv_and_parquet_together(filename, tmp_path):
+    """Test that save_bdf can write both CSV and parquet in a single call."""
+    import navani.echem as ec
+    import pandas as pd
+
+    pytest.importorskip("pyarrow")
+    df = ec.echem_file_loader(EXAMPLE_DATA / filename)
+    bdf_df = build_bdf_df(df)
+    csv_path = tmp_path / "export.bdf.csv"
+    parquet_path = tmp_path / "export.bdf.parquet"
+    save_bdf(bdf_df, parquet_path=parquet_path, csv_path=csv_path)
+
+    assert csv_path.exists()
+    assert parquet_path.exists()
+    csv_cols = set(pd.read_csv(csv_path).columns)
+    parquet_cols = set(pd.read_parquet(parquet_path).columns)
+    assert csv_cols == parquet_cols
+    assert _BDF_REQUIRED.issubset(csv_cols)
+
+
+def test_export_to_bdf_backwards_compat(tmp_path):
+    """Smoke test that export_to_bdf still works as a backwards-compat wrapper."""
+    import navani.echem as ec
+    import pandas as pd
+
+    pytest.importorskip("pyarrow")
+    df = ec.echem_file_loader(EXAMPLE_DATA / "example_output.csv")
+
+    export_to_bdf(df, filepath=tmp_path / "export", save_csv=True, save_parquet=True)
+    assert (tmp_path / "export.bdf.csv").exists()
+    assert (tmp_path / "export.bdf.parquet").exists()
+
+    bdf_only_df = export_to_bdf(df, bdf_only=True)
+    assert set(bdf_only_df.columns).issubset(_BDF_CANONICAL_COLUMNS)
+
+    bdf_df_with_navani = export_to_bdf(df)
+    assert {'Time', 'Voltage', 'Current'}.issubset(bdf_df_with_navani.columns)
 
 
 # ---------------------------------------------------------------------------
@@ -478,15 +497,15 @@ def test_local_files_bdf_round_trip(filepath, tmp_path):
 
     df_original = ec.echem_file_loader(filepath)
 
-    bdf_only_df = export_to_bdf(df_original, bdf_only=True)
-    navani_cols = {'Time', 'Voltage', 'Current', 'Capacity', 'state', 'half cycle', 'full cycle', 'cycle change'}
-    assert not navani_cols.intersection(bdf_only_df.columns), (
-        f"navani columns found in bdf_only output: {navani_cols.intersection(bdf_only_df.columns)}"
+    bdf_df = build_bdf_df(df_original)
+    assert not _NAVANI_COLS.intersection(bdf_df.columns), (
+        f"navani columns found in build_bdf_df output: {_NAVANI_COLS.intersection(bdf_df.columns)}"
     )
-    assert set(bdf_only_df.columns).issubset(_BDF_CANONICAL_COLUMNS)
+    assert set(bdf_df.columns).issubset(_BDF_CANONICAL_COLUMNS)
 
-    export_to_bdf(df_original, filepath=tmp_path / "export", save_csv=True)
-    df_reimported = ec.echem_file_loader(tmp_path / "export.bdf.csv")
+    csv_path = tmp_path / "export.bdf.csv"
+    save_bdf(bdf_df, csv_path=csv_path)
+    df_reimported = ec.echem_file_loader(csv_path)
 
     expected_cols = ("state", "cycle change", "half cycle", "Capacity", "Voltage", "Current", "full cycle")
     assert all(c in df_reimported for c in expected_cols)


### PR DESCRIPTION
### Restructure BDF export into build_bdf_df and save_bdf
  
  Previously export_to_bdf handled both DataFrame construction and file saving in one function, meaning callers who wanted both CSV and parquet output had to call it twice — running a full df.copy(),
  column build, and downcast on each call.

  This PR splits the function into two composable public functions:

  - build_bdf_df(df) — pure transform: copies the navani DataFrame, adds BDF-standard columns with unit conversions (mA→A, mAh→Ah), filters to BDF-only columns, and downcasts to float32/int32. Returns
  the BDF DataFrame with no side effects.
  - save_bdf(bdf_df, parquet_path=None, csv_path=None) — takes an already-built BDF DataFrame and writes to whichever paths are provided. Both, either, or neither can be specified in a single call.

  export_to_bdf is kept as a backwards-compatible wrapper delegating to both.

Tests updated to test build_bdf_df and save_bdf directly across all example file formats, with export_to_bdf covered by a single backwards-compat smoke test.